### PR TITLE
Removed backface-visibility due to a Firefox bug

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -56,7 +56,6 @@ body
   width: 100%;  
   position: absolute;
   padding: 20px;
-  backface-visibility: hidden;
 }
 
 .front-face


### PR DESCRIPTION
Someone pointed out that it wasn't working on Firefox, it was due to this leftover css. 